### PR TITLE
:green_apple: fixbug:: windows os error

### DIFF
--- a/ssh/client.go
+++ b/ssh/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"runtime"
 
 	"mysshw/config"
 
@@ -207,6 +208,10 @@ func (c *defaultClient) Login() {
 	}
 	defer terminal.Restore(fd, state)
 
+	//OS:windows
+	if runtime.GOOS == "windows" {
+		fd = int(os.Stdout.Fd())
+	}
 	w, h, err := terminal.GetSize(fd)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
run windows10 x64, error "The handle is invalid."

core line:210

`fd := int(os.Stdin.Fd())` in windows 

https://github.com/golang/go/issues/27743

